### PR TITLE
 fixed build_attrs() got an unexpected keyword argument 'name'

### DIFF
--- a/editormd/widgets.py
+++ b/editormd/widgets.py
@@ -15,7 +15,13 @@ class EditorMdWidget(forms.Textarea):
     def __init__(self, attrs=None):
         super(EditorMdWidget, self).__init__(attrs)
 
-    def render(self, name, value, attrs=None):
+    def build_attrs(self, base_attrs, extra_attrs=None, **kwargs):
+        attrs = dict(base_attrs, **kwargs)
+        if extra_attrs:
+            attrs.update(extra_attrs)
+        return attrs
+
+    def render(self, name, value, attrs=None, renderer=None):
         if value is None:
             value = ''
         final_attrs = self.build_attrs(attrs, name=name)


### PR DESCRIPTION
修复在 python3.6.1 Django 1.11.3 下 build_attrs() got an unexpected keyword argument 'name' 问题